### PR TITLE
Enforce CallTimeout, fix readme examples and flaky tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,39 +15,53 @@ type Plugin struct {
 }
 
 // create plugin (jrpc server) with NewServer where required param is a base url for rpc calls
-plugin := NewServer("/command")
+plugin := jrpc.NewServer("/command")
 
-// then add you function to map 
-plugin.Add("mycommand", func(id uint64, params json.RawMessage) Response {
+// then add your function to map
+plugin.Add("mycommand", func(id uint64, params json.RawMessage) jrpc.Response {
     return jrpc.EncodeResponse(id, "hello, it works", nil)
 })
 
 // and run server with port number value
-plugin.Run(9090)
+plugin.Run(8080)
 ```
 
-The constructor `NewServer` accept two parameters:
+The constructor `NewServer` accepts two parameters:
 * `API` - a base url for rpc calls
-* `Options` - optional parameters such is timeouts, logger, limits, middlewares and etc.
-  * `Auth` - set credentials basic auth to server, accepts `username` and `password`
-  * `WithTimeout` - sets global timeouts for server requests, such as read, write and idle. Call accept `Timeouts` struct.
-  * `WithLimits` - define limit for server call, accepts limit value in `float64` type
-  * `WithThrottler` - sets throttler middleware with specify limit value
-  * `WithtSignature` - sets server signature, accept appName, author and version. Disable by default. 
-  * `WithLogger` - define custom logger (e.g. [lgr](https://github.com/go-pkgz/lgr))
-  * `WithMiddlewares` - sets custom middlewares list to server, accepts list of handler with idiomatic type `func(http.Handler) http.Handler`
+* `Options` - optional parameters such as timeouts, logger, limits, middlewares and so on.
+  * `Auth` - sets basic auth credentials, accepts `username` and `password`. Auth is enforced only if both of them
+    set to non-empty values; setting just one leaves the server serving every request unauthenticated
+  * `WithTimeouts` - sets server timeouts, accepts a `Timeouts` struct with `ReadHeaderTimeout`, `WriteTimeout`,
+    `IdleTimeout` and `CallTimeout`. `CallTimeout` limits the time allowed for a single call and responds with `503` if exceeded
+  * `WithLimits` - defines a limit of calls/sec per client, accepts limit value in `float64` type
+  * `WithThrottler` - sets throttler middleware limiting the number of parallel calls to the server
+  * `WithSignature` - sets server signature, accepts appName, author and version. Disabled by default
+  * `WithLogger` - defines custom logger (e.g. [lgr](https://github.com/go-pkgz/lgr))
+  * `WithMiddlewares` - sets custom middlewares list to server, accepts list of handlers with idiomatic type `func(http.Handler) http.Handler`
 
 Example with options:
 ```go
-plugin := NewServer("/command",
-	    Auth("user", "password"),
-		WithTimeout(Timeouts{ReadHeaderTimeout: 5 * time.Second, WriteTimeout: 5 * time.Second, IdleTimeout: 10 * time.Second}),
-		WithThrottler(120),
-		WithLimits(100),
-        WithtSignature("the best plugin ever", "author", "1.0.0"),
-		WithMiddlewares(middleware.Heartbeat('/ping'), middleware.Profiler, middleware.StripSlashes),
+import (
+	"time"
+
+	"github.com/go-pkgz/jrpc"
+	"github.com/go-pkgz/rest"
 )
-``` 
+
+plugin := jrpc.NewServer("/command",
+	jrpc.Auth("user", "password"),
+	jrpc.WithTimeouts(jrpc.Timeouts{
+		ReadHeaderTimeout: 5 * time.Second,
+		WriteTimeout:      5 * time.Second,
+		IdleTimeout:       10 * time.Second,
+		CallTimeout:       30 * time.Second,
+	}),
+	jrpc.WithThrottler(120),
+	jrpc.WithLimits(100),
+	jrpc.WithSignature("the best plugin ever", "author", "1.0.0"),
+	jrpc.WithMiddlewares(rest.Trace),
+)
+```
 
 ### Application (client)
 
@@ -67,8 +81,40 @@ if err = json.Unmarshal(*resp.Result, &message); err != nil {
 }
 ```
 
-*for functional examples for both plugin and application see [_example](https://github.com/go-pkgz/jrpc/tree/master/_example)*
- 
+### Running the example
+
+[_example](https://github.com/go-pkgz/jrpc/tree/master/_example) has a working pair of a plugin and an application.
+Both are separate go modules pointing to the local jrpc with a `replace` directive, so no extra setup is needed
+beyond go 1.24 or later. Start the plugin first, in one terminal:
+
+```sh
+cd _example/plugin
+go run .
+```
+
+It registers two handlers and listens on port 8080:
+
+```
+[INFO] add handler for store.save
+[INFO] add handler for store.load
+[INFO] listen on [::]:8080
+```
+
+Then run the application in another terminal:
+
+```sh
+cd _example/application
+go run .
+```
+
+It calls the plugin three times and prints the results:
+
+```
+stored {TS:2025-01-12 12:00:00 +0000 UTC Value:12345} with id=54118548792
+loaded {TS:2025-01-12 12:00:00 +0000 UTC Value:12345} from id=54118548792
+can't load for id=something, not found
+```
+
 ## Technical details
  
  * `jrpc.Server` runs on user-defined port as a regular http server
@@ -95,7 +141,9 @@ if err = json.Unmarshal(*resp.Result, &message); err != nil {
  
 * Params can be a struct, primitive type or slice of values, even with different types.
 * Server defines `ServerFn` handler function to react on a POST request. The handler provided by the user.
-* Communication between the server and the caller can be protected with basic auth.
+* Communication between the server and the caller can be protected with basic auth. The protection is on only if
+  both user and password set with the `Auth` option; with either of them empty the server responds to every request
+  without asking for credentials.
 * [Client](https://github.com/go-pkgz/jrpc/blob/master/client.go) provides a single method `Call` and return `Response`
 
  <details><summary>response details:</summary>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ The constructor `NewServer` accepts two parameters:
   * `Auth` - sets basic auth credentials, accepts `username` and `password`. Auth is enforced only if both of them
     set to non-empty values; setting just one leaves the server serving every request unauthenticated
   * `WithTimeouts` - sets server timeouts, accepts a `Timeouts` struct with `ReadHeaderTimeout`, `WriteTimeout`,
-    `IdleTimeout` and `CallTimeout`. `CallTimeout` limits the time allowed for a single call and responds with `503` if exceeded
+    `IdleTimeout` and `CallTimeout`. `CallTimeout` limits the time allowed for a single call and responds with `503` if
+    exceeded, and has to be set below `WriteTimeout`, otherwise the write deadline kills the connection before the
+    `503` can be sent
   * `WithLimits` - defines a limit of calls/sec per client, accepts limit value in `float64` type
   * `WithThrottler` - sets throttler middleware limiting the number of parallel calls to the server
   * `WithSignature` - sets server signature, accepts appName, author and version. Disabled by default
@@ -52,9 +54,9 @@ plugin := jrpc.NewServer("/command",
 	jrpc.Auth("user", "password"),
 	jrpc.WithTimeouts(jrpc.Timeouts{
 		ReadHeaderTimeout: 5 * time.Second,
-		WriteTimeout:      5 * time.Second,
+		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       10 * time.Second,
-		CallTimeout:       30 * time.Second,
+		CallTimeout:       25 * time.Second,
 	}),
 	jrpc.WithThrottler(120),
 	jrpc.WithLimits(100),

--- a/client.go
+++ b/client.go
@@ -23,7 +23,7 @@ type Client struct {
 // Empty args will be ignored, single arg will be marshaled as-us and multiple args marshaled as []interface{}.
 // Returns Response and error. Note: Response has it's own Error field, but that onw controlled by server.
 // Returned error represent client-level errors, like failed http call, failed marshaling and so on.
-func (r *Client) Call(method string, args ...interface{}) (*Response, error) {
+func (r *Client) Call(method string, args ...any) (*Response, error) {
 
 	var b []byte
 	var err error

--- a/example_test.go
+++ b/example_test.go
@@ -28,9 +28,9 @@ func ExampleNewServer_options() {
 		jrpc.Auth("user", "password"),
 		jrpc.WithTimeouts(jrpc.Timeouts{
 			ReadHeaderTimeout: 5 * time.Second,
-			WriteTimeout:      5 * time.Second,
+			WriteTimeout:      30 * time.Second,
 			IdleTimeout:       10 * time.Second,
-			CallTimeout:       30 * time.Second,
+			CallTimeout:       25 * time.Second,
 		}),
 		jrpc.WithThrottler(120),
 		jrpc.WithLimits(100),

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,67 @@
+package jrpc_test
+
+import (
+	"encoding/json"
+	"log"
+	"time"
+
+	"github.com/go-pkgz/rest"
+
+	"github.com/go-pkgz/jrpc"
+)
+
+// ExampleNewServer shows the minimal server setup with a single method registered.
+func ExampleNewServer() {
+	plugin := jrpc.NewServer("/command")
+
+	plugin.Add("mycommand", func(id uint64, params json.RawMessage) jrpc.Response {
+		return jrpc.EncodeResponse(id, "hello, it works", nil)
+	})
+
+	// blocks until Shutdown called or the server failed
+	_ = plugin.Run(8080)
+}
+
+// ExampleNewServer_options shows the server setup with all the available options.
+func ExampleNewServer_options() {
+	plugin := jrpc.NewServer("/command",
+		jrpc.Auth("user", "password"),
+		jrpc.WithTimeouts(jrpc.Timeouts{
+			ReadHeaderTimeout: 5 * time.Second,
+			WriteTimeout:      5 * time.Second,
+			IdleTimeout:       10 * time.Second,
+			CallTimeout:       30 * time.Second,
+		}),
+		jrpc.WithThrottler(120),
+		jrpc.WithLimits(100),
+		jrpc.WithSignature("the best plugin ever", "author", "1.0.0"),
+		jrpc.WithLogger(jrpc.LoggerFunc(log.Printf)),
+		jrpc.WithMiddlewares(rest.Trace),
+	)
+
+	plugin.Add("mycommand", func(id uint64, params json.RawMessage) jrpc.Response {
+		return jrpc.EncodeResponse(id, "hello, it works", nil)
+	})
+
+	_ = plugin.Run(8080)
+}
+
+// ExampleClient_Call shows how an application calls the remote method.
+func ExampleClient_Call() {
+	rpcClient := jrpc.Client{
+		API:        "http://127.0.0.1:8080/command",
+		AuthUser:   "user",
+		AuthPasswd: "password",
+	}
+
+	resp, err := rpcClient.Call("mycommand")
+	if err != nil {
+		log.Fatalf("call failed: %v", err)
+	}
+
+	var message string
+	if err = json.Unmarshal(*resp.Result, &message); err != nil {
+		log.Fatalf("failed to decode result: %v", err)
+	}
+	log.Printf("got %q", message)
+}

--- a/jrpc.go
+++ b/jrpc.go
@@ -10,9 +10,9 @@ import (
 
 // Request encloses method name and all params
 type Request struct {
-	Method string      `json:"method"`           // method (function) name
-	Params interface{} `json:"params,omitempty"` // function arguments
-	ID     uint64      `json:"id"`               // unique call id
+	Method string `json:"method"`           // method (function) name
+	Params any    `json:"params,omitempty"` // function arguments
+	ID     uint64 `json:"id"`               // unique call id
 }
 
 // Response encloses result and error received from remote server
@@ -23,7 +23,7 @@ type Response struct {
 }
 
 // EncodeResponse convert anything (type interface{}) and incoming error (if any) to Response
-func EncodeResponse(id uint64, resp interface{}, e error) Response {
+func EncodeResponse(id uint64, resp any, e error) Response {
 	v, err := json.Marshal(&resp)
 	if err != nil {
 		return Response{Error: err.Error()}

--- a/options.go
+++ b/options.go
@@ -7,7 +7,9 @@ import (
 // Option func type
 type Option func(s *Server)
 
-// Auth sets basic auth credentials, required
+// Auth sets basic auth credentials, optional.
+// Auth enforced only if both user and password set to non-empty values, otherwise the server
+// keeps serving every request unauthenticated. Setting just one of them doesn't enable auth.
 func Auth(user, password string) Option {
 	return func(s *Server) {
 		s.authUser = user

--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -81,15 +82,28 @@ func NewServer(api string, options ...Option) *Server {
 	return srv
 }
 
-// Run http server on given port
+// Run http server on given port, blocks until Shutdown called or the server failed
 func (s *Server) Run(port int) error {
+
+	if len(s.funcs.m) == 0 {
+		return fmt.Errorf("nothing mapped for dispatch, Add has to be called prior to Run")
+	}
+
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		return fmt.Errorf("can't listen on port %d: %w", port, err)
+	}
+
+	s.activate()
+	return s.serve(ln)
+}
+
+// activate makes http server with all the middlewares and the dispatch handler.
+// after this call Add won't accept new methods.
+func (s *Server) activate() {
 
 	if s.authUser == "" || s.authPasswd == "" {
 		s.logger.Logf("[WARN] extension server runs without auth")
-	}
-
-	if s.funcs.m == nil && len(s.funcs.m) == 0 {
-		return fmt.Errorf("nothing mapped for dispatch, Add has to be called prior to Run")
 	}
 
 	router := routegroup.New(http.NewServeMux())
@@ -124,16 +138,26 @@ func (s *Server) Run(port int) error {
 
 	s.httpServer.Lock()
 	s.httpServer.Server = &http.Server{
-		Addr:              fmt.Sprintf(":%d", port),
 		Handler:           router,
 		ReadHeaderTimeout: s.timeouts.ReadHeaderTimeout,
 		WriteTimeout:      s.timeouts.WriteTimeout,
 		IdleTimeout:       s.timeouts.IdleTimeout,
 	}
 	s.httpServer.Unlock()
+}
 
-	s.logger.Logf("[INFO] listen on %d", port)
-	return s.httpServer.ListenAndServe()
+// serve runs activated http server on the provided listener
+func (s *Server) serve(l net.Listener) error {
+	s.httpServer.Lock()
+	srv := s.httpServer.Server
+	s.httpServer.Unlock()
+
+	if srv == nil {
+		return fmt.Errorf("server is not activated")
+	}
+
+	s.logger.Logf("[INFO] listen on %s", l.Addr())
+	return srv.Serve(l)
 }
 
 // Shutdown http server

--- a/server.go
+++ b/server.go
@@ -90,12 +90,13 @@ func (s *Server) Run(port int) error {
 		return fmt.Errorf("nothing mapped for dispatch, Add has to be called prior to Run")
 	}
 
+	s.activate()
+
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		return fmt.Errorf("can't listen on port %d: %w", port, err)
 	}
 
-	s.activate()
 	return s.serve(ln)
 }
 

--- a/server.go
+++ b/server.go
@@ -14,12 +14,13 @@ import (
 	"github.com/go-pkgz/routegroup"
 )
 
-// Server is json-rpc server with an optional basic auth
+// Server is json-rpc server with an optional basic auth.
+// Auth enforced only if both authUser and authPasswd set, see Auth option.
 type Server struct {
 	api string // url path, i.e. "/command" or "/rpc" etc., required
 
-	authUser          string      // basic auth user name, should match Client.AuthUser, optional
-	authPasswd        string      // basic auth password, should match Client.AuthPasswd, optional
+	authUser          string      // basic auth user name, should match Client.AuthUser, optional, no auth if empty
+	authPasswd        string      // basic auth password, should match Client.AuthPasswd, optional, no auth if empty
 	customMiddlewares middlewares // list of custom middlewares, should match array of http.Handler func, optional
 
 	signature signaturePayload // add server signature to server response headers appName, author, version), disable by default
@@ -103,7 +104,7 @@ func (s *Server) Run(port int) error {
 func (s *Server) activate() {
 
 	if s.authUser == "" || s.authPasswd == "" {
-		s.logger.Logf("[WARN] extension server runs without auth")
+		s.logger.Logf("[WARN] extension server runs without auth, both user and password have to be set to enable it")
 	}
 
 	router := routegroup.New(http.NewServeMux())
@@ -226,7 +227,8 @@ func (s *Server) handler(w http.ResponseWriter, r *http.Request) {
 	rest.RenderJSON(w, fn(req.ID, params))
 }
 
-// basicAuth middleware. enabled only if both AuthUser and AuthPasswd defined.
+// basicAuth middleware, enabled only if both authUser and authPasswd set to non-empty values.
+// with either of them empty every request passes through unauthenticated.
 func (s *Server) basicAuth(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 

--- a/server.go
+++ b/server.go
@@ -253,14 +253,11 @@ func getDefaultTimeouts() Timeouts {
 	}
 }
 
-// timeout middleware cancels context after given duration
+// timeout middleware limits the time allowed for the call, responds with 503 and drops
+// the late handler writes if the deadline reached
 func timeout(dt time.Duration) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx, cancel := context.WithTimeout(r.Context(), dt)
-			defer cancel()
-			h.ServeHTTP(w, r.WithContext(ctx))
-		})
+		return http.TimeoutHandler(h, dt, `{"error":"call timeout"}`)
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -265,17 +265,17 @@ func timeout(dt time.Duration) func(http.Handler) http.Handler {
 
 // L defined logger interface used for an optional rest logging
 type L interface {
-	Logf(format string, args ...interface{})
+	Logf(format string, args ...any)
 }
 
 // LoggerFunc type is an adapter to allow the use of ordinary functions as Logger.
-type LoggerFunc func(format string, args ...interface{})
+type LoggerFunc func(format string, args ...any)
 
 // Logf calls f(id)
-func (f LoggerFunc) Logf(format string, args ...interface{}) { f(format, args...) }
+func (f LoggerFunc) Logf(format string, args ...any) { f(format, args...) }
 
 // NoOpLogger logger does nothing
-var NoOpLogger = LoggerFunc(func(format string, args ...interface{}) {}) //nolint
+var NoOpLogger = LoggerFunc(func(format string, args ...any) {}) //nolint
 
 // rateLimitByIP returns middleware that limits requests per second for each client IP.
 // Uses X-Real-IP header (set by rest.RealIP middleware) for client identification.

--- a/server_test.go
+++ b/server_test.go
@@ -511,3 +511,48 @@ func TestServerServeNotActivated(t *testing.T) {
 	s := NewServer("/v1/cmd")
 	assert.EqualError(t, s.serve(l), "server is not activated")
 }
+
+func TestServerCallTimeout(t *testing.T) {
+	s := NewServer("/v1/cmd", WithTimeouts(Timeouts{
+		ReadHeaderTimeout: time.Second,
+		WriteTimeout:      5 * time.Second,
+		IdleTimeout:       time.Second,
+		CallTimeout:       50 * time.Millisecond,
+	}))
+
+	s.Add("fast", func(id uint64, _ json.RawMessage) Response {
+		return EncodeResponse(id, "done", nil)
+	})
+	s.Add("slow", func(id uint64, _ json.RawMessage) Response {
+		time.Sleep(500 * time.Millisecond)
+		return EncodeResponse(id, "too late", nil)
+	})
+
+	url := startServer(t, s)
+
+	t.Run("call within timeout", func(t *testing.T) {
+		c := Client{API: url + "/v1/cmd", Client: http.Client{}}
+		r, err := c.Call("fast")
+		require.NoError(t, err)
+		val := ""
+		require.NoError(t, json.Unmarshal(*r.Result, &val))
+		assert.Equal(t, "done", val)
+	})
+
+	t.Run("call over timeout aborted with 503", func(t *testing.T) {
+		b := bytes.Buffer{}
+		require.NoError(t, json.NewEncoder(&b).Encode(Request{Method: "slow", ID: 1}))
+
+		st := time.Now()
+		resp, err := http.Post(url+"/v1/cmd", "application/json", &b)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+		assert.Less(t, time.Since(st), 300*time.Millisecond, "response should not wait for the handler to finish")
+
+		data, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, `{"error":"call timeout"}`, string(data))
+	})
+}

--- a/server_test.go
+++ b/server_test.go
@@ -25,7 +25,7 @@ func TestServerPrimitiveTypes(t *testing.T) {
 	}
 
 	s.Add("test", func(id uint64, params json.RawMessage) Response {
-		var args []interface{}
+		var args []any
 		if err := json.Unmarshal(params, &args); err != nil {
 			return Response{Error: err.Error()}
 		}
@@ -42,7 +42,7 @@ func TestServerPrimitiveTypes(t *testing.T) {
 	url := startServer(t, s)
 
 	// check with direct http call
-	clientReq := Request{Method: "test", Params: []interface{}{"blah", 42, true}, ID: 123}
+	clientReq := Request{Method: "test", Params: []any{"blah", 42, true}, ID: 123}
 	b := bytes.Buffer{}
 	require.NoError(t, json.NewEncoder(&b).Encode(clientReq))
 	resp, err := http.Post(url+"/v1/cmd", "application/json", &b)
@@ -126,7 +126,7 @@ func TestServerWithAuth(t *testing.T) {
 	s := NewServer("/v1/cmd", Auth("user", "passwd"))
 
 	s.Add("test", func(id uint64, params json.RawMessage) Response {
-		var args []interface{}
+		var args []any
 		if err := json.Unmarshal(params, &args); err != nil {
 			return Response{Error: err.Error()}
 		}
@@ -160,7 +160,7 @@ func TestServerErrReturn(t *testing.T) {
 	s := NewServer("/v1/cmd", Auth("user", "passwd"))
 
 	s.Add("test", func(id uint64, params json.RawMessage) Response {
-		var args []interface{}
+		var args []any
 		if err := json.Unmarshal(params, &args); err != nil {
 			return Response{Error: err.Error()}
 		}
@@ -363,7 +363,7 @@ func TestServer_WithLogger(t *testing.T) {
 
 type testLogger struct{}
 
-func (l testLogger) Logf(format string, args ...interface{}) {}
+func (l testLogger) Logf(format string, args ...any) {}
 
 func TestRateLimitByIP(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/server_test.go
+++ b/server_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -38,15 +39,13 @@ func TestServerPrimitiveTypes(t *testing.T) {
 		return EncodeResponse(id, respData{"res blah", true}, nil)
 	})
 
-	go func() { _ = s.Run(9091) }()
-	defer func() { assert.NoError(t, s.Shutdown()) }()
-	time.Sleep(10 * time.Millisecond)
+	url := startServer(t, s)
 
 	// check with direct http call
 	clientReq := Request{Method: "test", Params: []interface{}{"blah", 42, true}, ID: 123}
 	b := bytes.Buffer{}
 	require.NoError(t, json.NewEncoder(&b).Encode(clientReq))
-	resp, err := http.Post("http://127.0.0.1:9091/v1/cmd", "application/json", &b)
+	resp, err := http.Post(url+"/v1/cmd", "application/json", &b)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 	assert.Equal(t, 200, resp.StatusCode)
@@ -55,7 +54,7 @@ func TestServerPrimitiveTypes(t *testing.T) {
 	assert.Equal(t, `{"result":{"Res1":"res blah","Res2":true},"id":123}`+"\n", string(data))
 
 	// check with client call
-	c := Client{API: "http://127.0.0.1:9091/v1/cmd", Client: http.Client{}}
+	c := Client{API: url + "/v1/cmd", Client: http.Client{}}
 	r, err := c.Call("test", "blah", 42, true)
 	assert.NoError(t, err)
 	assert.Equal(t, "", r.Error)
@@ -90,11 +89,9 @@ func TestServerWithObject(t *testing.T) {
 		return EncodeResponse(id, respData{"res blah", true}, nil)
 	})
 
-	go func() { _ = s.Run(9091) }()
-	defer func() { assert.NoError(t, s.Shutdown()) }()
-	time.Sleep(10 * time.Millisecond)
+	url := startServer(t, s)
 
-	c := Client{API: "http://127.0.0.1:9091/v1/cmd", Client: http.Client{}}
+	c := Client{API: url + "/v1/cmd", Client: http.Client{}}
 	r, err := c.Call("test", reqData{Time: time.Now(), F1: "sawert", F2: time.Minute})
 	assert.NoError(t, err)
 	assert.Equal(t, "", r.Error)
@@ -143,11 +140,9 @@ func TestServerWithAuth(t *testing.T) {
 		return EncodeResponse(id, "res blah", nil)
 	})
 
-	go func() { _ = s.Run(9091) }()
-	time.Sleep(10 * time.Millisecond)
-	defer func() { assert.NoError(t, s.Shutdown()) }()
+	url := startServer(t, s)
 
-	c := Client{API: "http://127.0.0.1:9091/v1/cmd", Client: http.Client{}, AuthUser: "user", AuthPasswd: "passwd"}
+	c := Client{API: url + "/v1/cmd", Client: http.Client{}, AuthUser: "user", AuthPasswd: "passwd"}
 	r, err := c.Call("test", "blah", 42, true)
 	assert.NoError(t, err)
 	assert.Equal(t, "", r.Error)
@@ -156,7 +151,7 @@ func TestServerWithAuth(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "res blah", val)
 
-	c = Client{API: "http://127.0.0.1:9091/v1/cmd", Client: http.Client{}}
+	c = Client{API: url + "/v1/cmd", Client: http.Client{}}
 	_, err = c.Call("test", "blah", 42, true)
 	assert.EqualError(t, err, "bad status 401 Unauthorized for test")
 }
@@ -179,11 +174,9 @@ func TestServerErrReturn(t *testing.T) {
 		return EncodeResponse(id, "res blah", fmt.Errorf("some error"))
 	})
 
-	go func() { _ = s.Run(9091) }()
-	defer func() { assert.NoError(t, s.Shutdown()) }()
-	time.Sleep(10 * time.Millisecond)
+	url := startServer(t, s)
 
-	c := Client{API: "http://127.0.0.1:9091/v1/cmd", Client: http.Client{}, AuthUser: "user", AuthPasswd: "passwd"}
+	c := Client{API: url + "/v1/cmd", Client: http.Client{}, AuthUser: "user", AuthPasswd: "passwd"}
 	_, err := c.Call("test", "blah", 42, true)
 	assert.EqualError(t, err, "some error")
 }
@@ -200,11 +193,9 @@ func TestServerGroup(t *testing.T) {
 		},
 	})
 
-	go func() { _ = s.Run(9091) }()
-	defer func() { assert.NoError(t, s.Shutdown()) }()
-	time.Sleep(10 * time.Millisecond)
+	url := startServer(t, s)
 
-	c := Client{API: "http://127.0.0.1:9091/v1/cmd", Client: http.Client{}}
+	c := Client{API: url + "/v1/cmd", Client: http.Client{}}
 	_, err := c.Call("fn1")
 	assert.EqualError(t, err, "bad status 501 Not Implemented for fn1")
 
@@ -220,16 +211,14 @@ func TestServerAddLate(t *testing.T) {
 	s.Add("fn1", func(id uint64, params json.RawMessage) Response {
 		return Response{}
 	})
-	go func() { _ = s.Run(9091) }()
-	defer func() { assert.NoError(t, s.Shutdown()) }()
-	time.Sleep(10 * time.Millisecond)
+	url := startServer(t, s)
 
 	// too late, ignored after run
 	s.Add("fn2", func(id uint64, params json.RawMessage) Response {
 		return Response{}
 	})
 
-	c := Client{API: "http://127.0.0.1:9091/v1/cmd", Client: http.Client{}}
+	c := Client{API: url + "/v1/cmd", Client: http.Client{}}
 	_, err := c.Call("fn1")
 	assert.NoError(t, err)
 	_, err = c.Call("fn2")
@@ -238,7 +227,7 @@ func TestServerAddLate(t *testing.T) {
 
 func TestServerNoHandlers(t *testing.T) {
 	s := NewServer("/v1/cmd", Auth("user", "passwd"))
-	assert.EqualError(t, s.Run(9091), "nothing mapped for dispatch, Add has to be called prior to Run")
+	assert.EqualError(t, s.Run(0), "nothing mapped for dispatch, Add has to be called prior to Run")
 }
 
 func TestServer_getDefaultTimeouts(t *testing.T) {
@@ -291,14 +280,11 @@ func TestServer_WithSignature(t *testing.T) {
 	s.Add("fn1", func(id uint64, params json.RawMessage) Response {
 		return Response{}
 	})
-	go func() { _ = s.Run(9091) }()
-	time.Sleep(10 * time.Millisecond)
+	url := startServer(t, s)
 
-	c := Client{API: "http://127.0.0.1:9091/v1/cmd", Client: http.Client{}}
+	c := Client{API: url + "/v1/cmd", Client: http.Client{}}
 	_, err := c.Call("fn1")
 	assert.NoError(t, err)
-	assert.NoError(t, s.Shutdown())
-	time.Sleep(10 * time.Millisecond)
 
 	// checking signature with server response
 	checkSignatureMiddlewareFn = func(next http.Handler) http.Handler {
@@ -319,14 +305,11 @@ func TestServer_WithSignature(t *testing.T) {
 		return Response{}
 	})
 
-	go func() { _ = s.Run(9091) }()
-	defer func() { assert.NoError(t, s.Shutdown()) }()
-	time.Sleep(10 * time.Millisecond)
+	signedURL := startServer(t, s)
 
-	c = Client{API: "http://127.0.0.1:9091/v1/cmd", Client: http.Client{}}
+	c = Client{API: signedURL + "/v1/cmd", Client: http.Client{}}
 	_, err = c.Call("fn1")
 	assert.NoError(t, err)
-
 }
 
 func TestServerCustomMiddlewares(t *testing.T) {
@@ -363,22 +346,19 @@ func TestServerCustomMiddlewares(t *testing.T) {
 	s.Add("fn1", func(id uint64, params json.RawMessage) Response {
 		return Response{}
 	})
-	go func() { _ = s.Run(9091) }()
-	time.Sleep(10 * time.Millisecond)
-	defer func() { assert.NoError(t, s.Shutdown()) }()
-	c := Client{API: "http://127.0.0.1:9091/v1/cmd?value=test", Client: http.Client{}}
+	url := startServer(t, s)
+
+	c := Client{API: url + "/v1/cmd?value=test", Client: http.Client{}}
 	_, err := c.Call("fn1")
 	assert.NoError(t, err)
-	time.Sleep(10 * time.Millisecond)
-
 }
 
 func TestServer_WithLogger(t *testing.T) {
 	s := NewServer("")
-	assert.Equal(t, reflect.TypeOf(s.logger), reflect.TypeOf(NoOpLogger))
+	assert.Equal(t, reflect.TypeOf(s.logger), reflect.TypeFor[LoggerFunc]())
 
 	s = NewServer("", WithLogger(testLogger{}))
-	assert.Equal(t, reflect.TypeOf(s.logger), reflect.TypeOf(testLogger{}))
+	assert.Equal(t, reflect.TypeOf(s.logger), reflect.TypeFor[testLogger]())
 }
 
 type testLogger struct{}
@@ -395,7 +375,7 @@ func TestRateLimitByIP(t *testing.T) {
 		ts := httptest.NewServer(limiter(handler))
 		defer ts.Close()
 
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			resp, err := http.Get(ts.URL)
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -409,7 +389,7 @@ func TestRateLimitByIP(t *testing.T) {
 		defer ts.Close()
 
 		var rejected bool
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			resp, err := http.Get(ts.URL)
 			require.NoError(t, err)
 			if resp.StatusCode == http.StatusTooManyRequests {
@@ -458,7 +438,7 @@ func TestRateLimitByIP(t *testing.T) {
 		defer ts.Close()
 
 		// exhaust all tokens
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			resp, err := http.Get(ts.URL)
 			require.NoError(t, err)
 			_ = resp.Body.Close()
@@ -479,4 +459,55 @@ func TestRateLimitByIP(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		_ = resp.Body.Close()
 	})
+}
+
+// startServer runs s on a random port and returns its base url. the listener is bound and the server
+// activated before serve starts, so no readiness wait needed. shutdown and serve error checked on cleanup.
+func startServer(t *testing.T, s *Server) string {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	s.activate()
+	done := make(chan error, 1)
+	go func() { done <- s.serve(l) }()
+
+	t.Cleanup(func() {
+		assert.NoError(t, s.Shutdown())
+		assert.ErrorIs(t, <-done, http.ErrServerClosed)
+	})
+
+	return "http://" + l.Addr().String()
+}
+
+func TestServerRunFailedToListen(t *testing.T) {
+	l, err := net.Listen("tcp", ":0") //nolint:gosec // has to bind the same way Run does to collide with it
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, l.Close()) }()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	s := NewServer("/v1/cmd")
+	s.Add("test", func(uint64, json.RawMessage) Response { return Response{} })
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(port) }()
+
+	select {
+	case err = <-done:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), fmt.Sprintf("can't listen on port %d", port))
+	case <-time.After(time.Second):
+		assert.NoError(t, s.Shutdown())
+		t.Fatal("expected Run to fail on the busy port")
+	}
+}
+
+func TestServerServeNotActivated(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, l.Close()) }()
+
+	s := NewServer("/v1/cmd")
+	assert.EqualError(t, s.serve(l), "server is not activated")
 }


### PR DESCRIPTION
Fixes a set of server-side defects found while auditing the library.

**CallTimeout enforcement.** Previously, `CallTimeout` only attached a deadline to the request context, and `ServerFn` has no access to that context, so a slow or blocked handler ran to completion and the caller waited for it regardless of the configured value. After this change the middleware is built on `http.TimeoutHandler`, which aborts the call at the deadline, responds with `503` and a json error body, and drops late writes from the handler. The handler work itself still cannot be cancelled, that would need a context-aware `ServerFn`.

**Listener handling and tests.** `Run` is split into unexported `activate` and `serve`, so the server can be started on a pre-bound listener. Tests now bind `127.0.0.1:0` and start on that listener instead of racing `Run` on the hardcoded port 9091, discarding the bind error and sleeping 10ms in the hope the server was up. `Run` also reports a bind failure wrapped with the port number, and rejects an empty dispatch map before taking the port.

**Basic auth documentation.** Authentication is enforced only when both user and password are non-empty, and with either of them empty the server answers every request. This was stated nowhere except a warning in the log, so a partially configured plugin looked protected when it was not. The behaviour is unchanged, the documentation now describes it.

**README and examples.** The options example used `WithTimeout` and `WithtSignature`, neither of which exists, along with a chi middleware list containing an invalid rune literal, so the block could not compile. It is corrected and mirrored by compile-checked `Example` functions in `example_test.go`. The README also documents how to run the plugin and the application from `_example`.

The last commit is the output of `go fix`, replacing `interface{}` with `any` across the package.

Two findings are deliberately left out. The per-client rate limiter keys buckets on a client-controlled header and keeps them in a map that never evicts, and throttle slots are held for as long as a client stalls the request body. Both need an API decision and will follow separately.
